### PR TITLE
Add reservation creation date to reservations table

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -557,6 +557,7 @@ function getTodasReservas() {
     filterFn: () => true,
     // mismo formateo plano que en mis reservas
     formatFn: r => ({
+      FechaReserva: formatFecha(r.creada),
       ID:       r.id,
       Sala:     r.nombre,
       Capacidad: r.capacidad,

--- a/reservas.html
+++ b/reservas.html
@@ -59,6 +59,7 @@
     <table id="allReservasTable" class="table-style">
       <thead>
         <tr>
+          <th data-sort="FechaReserva">Fecha reserva</th>
           <th data-sort="ID">ID Reserva</th>
           <th data-sort="Sala">Sala</th>
           <th data-sort="Capacidad">Capacidad</th>
@@ -333,6 +334,7 @@
 
     _sortValue(row, key) {
       switch (key) {
+        case 'FechaReserva': return this.parseFechaDMY(row.FechaReserva);
         case 'Inicio': return this.parseFechaDMY(row.Inicio);
         case 'Fin':    return this.parseFechaDMY(row.Fin);
         default:
@@ -377,7 +379,7 @@
       this.updateSortIndicators();
 
       if (!datos.length) {
-        tbody.innerHTML = '<tr><td colspan="10" style="text-align:center;color:#bc348b;">No hay reservas</td></tr>';
+        tbody.innerHTML = '<tr><td colspan="11" style="text-align:center;color:#bc348b;">No hay reservas</td></tr>';
         return;
       }
 
@@ -385,6 +387,7 @@
       datos.forEach(r => {
         tbody.insertAdjacentHTML('beforeend', `
           <tr data-id="${r.ID}">
+            <td>${r.FechaReserva || ''}</td>
             <td>${r.ID}</td>
             <td>${r.Sala}</td>
             <td>${r.Capacidad ?? ''}</td>


### PR DESCRIPTION
## Summary
- include the reservation creation timestamp in the dataset returned by `getTodasReservas`
- render the creation date as the first sortable column in `reservas.html`
- adjust table helpers to support sorting and empty-state colspan for the new column

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68de80dfc9e48320a67c613153b43cc0