### PR TITLE
Allow updating centro IDs safely

### DIFF
--- a/code.gs
+++ b/code.gs
@@ -2101,10 +2101,21 @@ function actualizarCentro(centro) {
   const idxResp = h('Responsable');
   const idxImagen = h('Imagen Centro');
   if (idxId === -1) throw new Error("No se encuentra la columna 'ID Centro'.");
-  const id = String(centro.idCentro || centro['ID Centro'] || '').trim();
+
+  const newId = String(centro.idCentro || centro['ID Centro'] || '').trim();
+  const originalId = String(centro.originalId || '').trim() || newId;
+
+  if (!originalId) throw new Error('ID original del centro no proporcionado.');
+
+  if (newId && newId !== originalId) {
+    const duplicate = rows.some(r => String(r[idxId]).trim() === newId);
+    if (duplicate) throw new Error('Ya existe un centro con ese ID.');
+  }
+
   for (let i = 0; i < rows.length; i++) {
-    if (String(rows[i][idxId]).trim() === id) {
+    if (String(rows[i][idxId]).trim() === originalId) {
       const row = i + 2;
+      if (idxId   !== -1) sheet.getRange(row, idxId   + 1).setValue(newId || originalId);
       if (idxNom  !== -1) sheet.getRange(row, idxNom  + 1).setValue(centro.NombreCentro || centro.nombre || '');
       if (idxDir  !== -1) sheet.getRange(row, idxDir  + 1).setValue(centro.DireccionCentro || centro['Direccion Centro'] || '');
       if (idxTel  !== -1) sheet.getRange(row, idxTel  + 1).setValue(centro.Telefono || '');

--- a/panelcontrol.html
+++ b/panelcontrol.html
@@ -930,6 +930,7 @@ const PanelAdmin = (() => {
     const nombreCentro = qs('#centroNombre').value.trim();
     const payload = {
       idCentro: qs('#centroId').value.trim(),
+      originalId: currentCentroId ? String(currentCentroId).trim() : '',
       NombreCentro: nombreCentro,
       'Nombre Centro': nombreCentro,
       'Direccion Centro': qs('#centroDireccion').value.trim(),


### PR DESCRIPTION
## Summary
- include the original centro identifier in the admin panel payload so edits can relocate the correct record
- update the Apps Script centro update routine to handle ID changes safely and check for duplicates

## Testing
- not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de843854c483209fe866145cd1d0fc